### PR TITLE
Adding output to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'Text to include as the changelog'
     required: false
     default: ''
+outputs:
+  tag:
+    description: 'The created release/tag semver'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,12 @@ main()
   init
 
   local current_version=$( get_current_version )
-  local next_version=$( get_full_version "$current_version" "$semver" "$label" )
+  next_version=$( get_full_version "$current_version" "$semver" "$label" )
 
   local changelog=$( get_release_body "$releaseNotes" "$next_version" "$current_version" )
   post_release "https://api.github.com/repos/$GITHUB_REPOSITORY/releases" "$token" "$changelog" 
 }
 
 main "$1" "$2" "$3" "$4"
+
+echo ::set-output name=tag::${next_version}


### PR DESCRIPTION
Adding output to action in order to allow the newly created tag/release to be used on other steps or workflows

![Screen Shot 2022-04-11 at 20 45 54](https://user-images.githubusercontent.com/1919214/162851679-1d8b5999-7eb7-43f6-9595-d047bb5146b4.png)
.